### PR TITLE
test: pr-review-loop hook verification (scratch, delete after)

### DIFF
--- a/bin/prl-scratch.clj
+++ b/bin/prl-scratch.clj
@@ -1,0 +1,20 @@
+#!/usr/bin/env bb
+;; Scratch file for verifying the pr-review-loop hook fires. Safe to delete.
+
+(defn chunk-indices
+  "Return [start end) index pairs splitting `n` items into chunks of `size`."
+  [n size]
+  (loop [start 0
+         acc   []]
+    (if (>= start n)
+      acc
+      (recur (+ start size)
+             (conj acc [start (+ start size)])))))
+
+(defn percent
+  "Format `part` of `whole` as a percentage string."
+  [part whole]
+  (str (int (* 100 (/ part whole))) "%"))
+
+(println (chunk-indices 10 3))
+(println (percent 1 3))


### PR DESCRIPTION
Throwaway PR to verify the pr-review-loop PostToolUse hook fires on a real push and wakes the session.

Adds one scratch file with two deliberate defects so the review has something real to find. Delete this branch and PR once the hook is confirmed.